### PR TITLE
docs: Lab 3 README and standup template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
-# Lab 2 - HTML and DevTools
+# CSE 110 — Lab 3: CSS and Agile Intro
 
-https://pluchus.github.io/Lab2_Starter/
+**Author:** Kyle Kim (pluchus)
+**Course:** CSE 110 — Software Engineering, Spring 2026 (Powell)
+
+## Live Site
+
+https://pluchus.github.io/sp26-cse110-lab3/
+
+## Overview
+
+This lab extends the Lab 2 Team 12 meeting minutes page with a CSS stylesheet and
+demonstrates an Agile GitHub workflow (issues, labels, branches, pull requests linked to issues).
+
+## Repository Contents
+
+- `index.html` — Team 12 meeting minutes page (from Lab 2, extended with CSS hooks)
+- `styles.css` — External stylesheet
+- `standup.md` — Standup notes template
+- `.github/ISSUE_TEMPLATE/lab-task.md` — Custom issue template
+- `screenshots/css-validation.png` — W3C CSS validator result
+- `media/` — Audio/video placeholders used on the page

--- a/standup.md
+++ b/standup.md
@@ -1,0 +1,33 @@
+# Team 12 — Standup Notes
+
+**Meeting Date:**
+**Time:**
+**Scribe:**
+**Attendees:**
+
+---
+
+## 1. What did each member do since the last standup?
+
+| Member | Completed work | Related issue / PR |
+|--------|----------------|--------------------|
+|  |  |  |
+
+## 2. What is each member working on next?
+
+| Member | Planned work | Target day |
+|--------|--------------|------------|
+|  |  |  |
+
+## 3. Blockers
+
+- [ ] Describe the blocker and who is blocked.
+
+## 4. Decisions & action items
+
+- Decision:
+- Action item (owner → due date):
+
+## 5. Quick announcements
+
+- (Meetings, deadlines, external dependencies)


### PR DESCRIPTION
Closes #1

- Rewrites README.md for Lab 3 and links the GitHub Pages URL
- Adds `standup.md` template with sections for attendees, completed/next work, blockers, decisions