### PR TITLE
feat: base CSS for meeting minutes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,24 +5,37 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Team 12 Meeting Minutes</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="styles.css">
+
+    <style>
+        /* small internal override so the first meeting date pops */
+        #notes > h3 {
+            letter-spacing: 0.02em;
+        }
+    </style>
 </head>
 <body>
 
-<header>
+<header class="site-header">
     <h1>Team 12 Meeting Minutes</h1>
-    <nav>
+    <nav class="site-nav">
         <a href="#notes">Notes</a> |
         <a href="#feedback">Feedback</a>
     </nav>
 </header>
 
-<main>
-    <section id="notes">
+<main class="layout">
+    <section id="notes" class="card">
         <h2>Brainstorming</h2>
         <h3>April 7, 2026</h3>
 
         <p><b>Attendance:</b></p>
-        <ol>
+        <ol class="attendance">
             <li>Julian</li>
             <li>Zhengyin</li>
             <li>Kyle</li>
@@ -36,46 +49,48 @@
             <li>Varsha</li>
         </ol>
 
-        <div>
-            <p><strong>Agenda</strong></p>
-            <ul>
-                <li>Introductions</li>
-                <li>Go over team contract</li>
-                <li>Brainstorm project ideas</li>
-                <li>Set up <em>Slack</em></li>
-            </ul>
+        <div class="minute-grid">
+            <div class="minute-block">
+                <p><strong>Agenda</strong></p>
+                <ul>
+                    <li>Introductions</li>
+                    <li>Go over team contract</li>
+                    <li>Brainstorm project ideas</li>
+                    <li>Set up <em>Slack</em></li>
+                </ul>
+            </div>
+
+            <div class="minute-block">
+                <p><b>Unfinished business</b></p>
+                <ul>
+                    <li>Nothing, this is the first meeting</li>
+                </ul>
+            </div>
+
+            <div class="minute-block">
+                <p><strong>New business</strong></p>
+                <ul>
+                    <li>We need to decide on a <i>team name</i> and theme</li>
+                    <li>Julian will submit group assignments on Canvas</li>
+                    <li>Meetings will be <b>Mondays at 4pm</b> on Zoom</li>
+                </ul>
+            </div>
+
+            <div class="minute-block">
+                <p><em>Misc</em></p>
+                <ul>
+                    <li>Everyone fill out <a href="https://www.when2meet.com">when2meet</a> by Friday</li>
+                    <li>Julian will post updates in Slack</li>
+                </ul>
+            </div>
         </div>
 
-        <div>
-            <p><b>Unfinished business</b></p>
-            <ul>
-                <li>Nothing, this is the first meeting</li>
-            </ul>
-        </div>
-
-        <div>
-            <p><strong>New business</strong></p>
-            <ul>
-                <li>We need to decide on a <i>team name</i> and theme</li>
-                <li>Julian will submit group assignments on Canvas</li>
-                <li>Meetings will be <b>Mondays at 4pm</b> on Zoom</li>
-            </ul>
-        </div>
-
-        <div>
-            <p><em>Misc</em></p>
-            <ul>
-                <li>Everyone fill out <a href="https://www.when2meet.com">when2meet</a> by Friday</li>
-                <li>Julian will post updates in Slack</li>
-            </ul>
-        </div>
-
-        <hr>
+        <hr style="border-top: 2px dashed currentColor; margin: 1.5rem 0;">
 
         <p>Whiteboard from the meeting:<br>
         <img src="screenshots/example.png" alt="whiteboard from meeting" width="400"></p>
 
-        <p><span>Recording:</span></p>
+        <p><span class="recording-label">Recording:</span></p>
         <audio controls>
             <source src="media/meeting1.mp3" type="audio/mpeg">
             Your browser does not support audio.
@@ -90,9 +105,9 @@
         </details>
     </section>
 
-    <section id="feedback">
+    <section id="feedback" class="card">
         <h2>Feedback</h2>
-        <form>
+        <form class="feedback-form">
             <fieldset>
                 <legend>Rate this meeting</legend>
                 <input type="radio" name="rating" value="good" id="good">
@@ -137,7 +152,7 @@
                 <label for="comments">Comments:</label><br>
                 <textarea id="comments" name="comments" rows="3" cols="30"></textarea>
             </p>
-            <button type="submit">Submit</button>
+            <button type="submit" class="primary">Submit</button>
         </form>
     </section>
 </main>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,257 @@
+/* Lab 3, Team 12 Meeting Minutes
+   CSE 110 SP26, Kyle Kim */
+
+/* theme variables */
+:root {
+    --primary: #1f3b57;
+    --primary-soft: rgba(31, 59, 87, 0.1);
+    --accent: hsl(28, 90%, 55%);
+    --accent-mix: color-mix(in srgb, hsl(28, 90%, 55%) 70%, white);
+    --p3-highlight: color(display-p3 0.95 0.88 0.72);
+    --paper: #faf7f2;
+    --ink: rgb(32, 32, 38);
+    --muted: hsla(215, 10%, 40%, 0.75);
+    --border: #d9d3c7;
+    --radius: 10px;
+}
+
+/* universal reset so box sizing is consistent */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Space Grotesk', sans-serif;
+    color: var(--ink, #222);
+    background-color: var(--paper);
+    line-height: 1.55;
+
+    /* absolute units: px, pt, cm */
+    font-size: 12pt;
+    padding: 24px;
+    max-width: 28cm;
+    margin-top: 0;
+    margin-right: auto;
+    margin-bottom: 0;
+    margin-left: auto;
+    min-height: 100vh;
+}
+
+/* selector list */
+h1, h2, h3 {
+    color: var(--primary);
+    font-weight: 700;
+    margin-bottom: 0.5em;
+}
+
+h1 {
+    font-size: 2rem;
+    text-align: center;
+    letter-spacing: 0.01em;
+}
+
+h2 {
+    font-size: 1.5rem;
+    border-bottom: 3px solid var(--accent);
+    border-radius: 2px;
+    padding-bottom: 0.25rem;
+    margin-bottom: 1rem;
+}
+
+h3 {
+    font-size: 1.15rem;
+    color: var(--muted);
+    text-decoration: underline;
+    text-align: left;
+}
+
+/* descendant combinator, any anchor inside site-nav */
+.site-nav a {
+    color: var(--primary);
+    text-decoration: none;
+    padding: 6px 10px;
+    border-radius: 6px;
+}
+
+/* child combinator, direct anchor children only */
+.site-nav > a {
+    background-color: var(--primary-soft);
+}
+
+/* element selector with class (element.class) */
+button.primary {
+    background-color: var(--accent);
+    color: white;
+    font-family: inherit;
+    font-size: 1rem;
+
+    /* short padding */
+    padding: 8px 18px;
+
+    /* short margin */
+    margin: 12px 0 0 0;
+
+    border-style: solid;
+    border-color: var(--accent-mix);
+    border-width: 2px;
+    border-radius: var(--radius);
+}
+
+/* site-header, using long-hand padding */
+.site-header {
+    background: var(--p3-highlight);
+    padding-top: 16px;
+    padding-right: 16px;
+    padding-bottom: 16px;
+    padding-left: 16px;
+    border-radius: var(--radius);
+    margin-bottom: 1.5rem;
+}
+
+/* card, shared look for both sections */
+.card {
+    background-color: #ffffff;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1rem;
+    min-width: 0;
+}
+
+/* id selector */
+#feedback {
+    max-width: 540px;
+}
+
+/* id selector */
+#notes {
+    color: var(--ink);
+}
+
+/* attendance list, styled like a ticket strip */
+.attendance {
+    background-color: var(--primary-soft);
+    border-radius: 6px;
+
+    /* auto margin horizontally, long-hand padding */
+    margin: 0 auto 1rem auto;
+    padding-top: 8px;
+    padding-right: 16px;
+    padding-bottom: 8px;
+    padding-left: 28px;
+
+    /* relative units: rem, em, % */
+    width: 100%;
+    font-size: 0.95rem;
+    line-height: 1.4em;
+}
+
+.attendance li {
+    /* keep default left margin for list items */
+    margin-left: 0.5em;
+}
+
+/* attribute selector for text inputs */
+input[type="text"] {
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 6px 8px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    width: 100%;
+    max-width: 320px;
+    min-width: 120px;
+}
+
+/* attribute selector variation */
+input[type="date"] {
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 6px 8px;
+}
+
+/* inputs + textarea: selector list */
+input, textarea, select {
+    background-color: white;
+    color: var(--ink);
+}
+
+textarea {
+    width: 100%;
+    max-width: 480px;
+    min-width: 200px;
+    height: 80px;
+    font-family: inherit;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 6px 8px;
+}
+
+/* adjacent sibling, input right before label */
+input + label {
+    margin-left: 4px;
+    color: var(--ink);
+}
+
+/* general sibling, any paragraph inside notes that comes after the h2 */
+#notes h2 ~ p {
+    margin-bottom: 0.5rem;
+}
+
+/* labels (element selector) */
+label {
+    color: var(--muted);
+    text-decoration: none;
+    text-align: left;
+}
+
+fieldset {
+    border: 2px solid var(--border);
+    border-radius: var(--radius);
+    padding: 10px 14px;
+    margin-bottom: 12px;
+}
+
+legend {
+    color: var(--primary);
+    padding: 0 6px;
+    font-weight: 500;
+}
+
+img {
+    max-width: 100%;
+    border-radius: 6px;
+}
+
+details {
+    margin-top: 12px;
+    padding: 6px 8px;
+    border: 1px dashed var(--border);
+    border-radius: 6px;
+}
+
+summary {
+    cursor: pointer;
+    color: var(--primary);
+    font-weight: 500;
+}
+
+.recording-label {
+    font-family: 'JetBrains Mono', monospace;
+    color: orange;
+    font-size: 0.9rem;
+}
+
+footer {
+    text-align: center;
+    color: var(--muted);
+    margin-top: 2rem;
+    font-size: 0.85rem;
+}
+
+footer p {
+    /* trailing note styling */
+    padding: 8px 0;
+}


### PR DESCRIPTION
Closes #3

## What's in
- `styles.css` with theme variables, typography, box model, sizing
- Google Font (Space Grotesk + JetBrains Mono) loaded via `<link>` in `index.html`
- Internal `<style>` block for a small heading override (internal CSS example)
- Inline `style` on the notes divider (inline CSS example)
- Classes and wrapper div added to HTML for future layout targeting

## Checklist coverage (Issue #3)
- Color formats: rgb, rgba, hex, hsl, hsla, named, color(), color-mix() ✓
- CSS variable with fallback: `var(--ink, #222)` ✓
- Relative units: rem, em, % ✓
- Absolute units: px, pt, cm ✓
- Box model: margin long + short + auto, padding long + short, border (style/color/width/radius) ✓
- Text: color, text-decoration, text-align ✓
- Sizing: height, width, max-width, min-width ✓
- Selectors (so far): class, id, universal, element, attribute, selector list, descendant, child (`>`), adjacent sibling (`+`), general sibling (`~`), element.class ✓